### PR TITLE
Expose brush dependencies, simplify BrushBuilder

### DIFF
--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -23,14 +23,14 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    let (device, queue, surface, _, mut config, format) = WgpuUtils::init(&window);
+    let (device, queue, surface, mut config) = WgpuUtils::init(&window);
 
     // All wgpu-text related below:
     let font: &[u8] = include_bytes!("fonts/Inconsolata-Regular.ttf");
     let mut brush = BrushBuilder::using_font_bytes(font)
         .unwrap()
         .with_depth_testing(true)
-        .build(&device, format, config.width as f32, config.height as f32);
+        .build(&device, &config);
 
     let mut font_size = 45.;
     let mut section = Section::default()

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -32,15 +32,13 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    let (device, queue, surface, _, mut config, format) = WgpuUtils::init(&window);
+    let (device, queue, surface, mut config) = WgpuUtils::init(&window);
 
     let font: &[u8] = include_bytes!("fonts/DejaVuSans.ttf");
-    let mut brush = BrushBuilder::using_font_bytes(font).unwrap().build(
-        &device,
-        format,
-        config.width as f32,
-        config.height as f32,
-    );
+    let mut brush = BrushBuilder::using_font_bytes(font)
+        .unwrap()
+        .build(&device, &config);
+
     let mut random_text = generate_random_chars();
     let mut font_size: f32 = 9.;
 

--- a/examples/scissoring.rs
+++ b/examples/scissoring.rs
@@ -23,16 +23,15 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    let (device, queue, surface, _, mut config, format) = WgpuUtils::init(&window);
+    let (device, queue, surface, mut config) = WgpuUtils::init(&window);
 
     // All wgpu-text related below:
     let font: &[u8] = include_bytes!("fonts/Inconsolata-Regular.ttf");
-    let mut brush = BrushBuilder::using_font_bytes(font).unwrap().build(
-        &device,
-        format,
-        config.width as f32,
-        config.height as f32,
-    );
+
+    let mut brush = BrushBuilder::using_font_bytes(font)
+        .unwrap()
+        .build(&device, &config);
+
     let mut font_size = 25.;
     let mut section = Section::default()
         .add_text(

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -21,16 +21,13 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    let (device, queue, surface, _, mut config, format) = WgpuUtils::init(&window);
+    let (device, queue, surface, _, mut config) = WgpuUtils::init(&window);
 
     // All wgpu-text related below:
     let font: &[u8] = include_bytes!("fonts/Inconsolata-Regular.ttf");
-    let mut brush = BrushBuilder::using_font_bytes(font).unwrap().build(
-        &device,
-        format,
-        config.width as f32,
-        config.height as f32,
-    );
+    let mut brush = BrushBuilder::using_font_bytes(font)
+        .unwrap()
+        .build(&device, &config);
     let mut font_size = 25.;
     let mut section = Section::default()
         .add_text(
@@ -222,9 +219,7 @@ impl WgpuUtils {
         wgpu::Device,
         wgpu::Queue,
         wgpu::Surface,
-        wgpu::Adapter,
         wgpu::SurfaceConfiguration,
-        wgpu::TextureFormat,
     ) {
         let backends = wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::Backends::all);
         let instance = wgpu::Instance::new(backends);
@@ -249,6 +244,7 @@ impl WgpuUtils {
             None,
         ))
         .unwrap();
+
         let format = surface.get_preferred_format(&adapter).unwrap();
         let config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
@@ -258,6 +254,6 @@ impl WgpuUtils {
             present_mode: wgpu::PresentMode::Mailbox,
         };
         surface.configure(&device, &config);
-        (device, queue, surface, adapter, config, format)
+        (device, queue, surface, config)
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -3,6 +3,8 @@ use std::num::NonZeroU32;
 use glyph_brush::Rectangle;
 use wgpu::util::DeviceExt;
 
+use crate::Matrix;
+
 /// Responsible for texture caching and matrix.
 pub struct Cache {
     pub bind_group_layout: wgpu::BindGroupLayout,
@@ -17,7 +19,7 @@ impl Cache {
     pub fn new(
         device: &wgpu::Device,
         tex_dimensions: (u32, u32),
-        matrix: [[f32; 4]; 4],
+        matrix: Matrix,
     ) -> Self {
         let texture = Self::create_cache_texture(device, tex_dimensions);
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
@@ -134,7 +136,7 @@ impl Cache {
         });
     }
 
-    pub fn update_matrix(&mut self, matrix: [[f32; 4]; 4], queue: &wgpu::Queue) {
+    pub fn update_matrix(&mut self, matrix: Matrix, queue: &wgpu::Queue) {
         queue.write_buffer(&self.matrix_buffer, 0, bytemuck::cast_slice(&matrix));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub mod section {
     };
 }
 
-use glyph_brush::{
+pub use glyph_brush::{
     ab_glyph::{Font, FontArc, FontRef, InvalidFont},
     BrushAction, DefaultSectionHasher, Extra, Section,
 };
@@ -291,9 +291,7 @@ where
     pub fn build(
         self,
         device: &wgpu::Device,
-        render_format: wgpu::TextureFormat,
-        width: f32,
-        height: f32,
+        config: &wgpu::SurfaceConfiguration,
     ) -> TextBrush<F, H> {
         let depth = if self.depth_test {
             Some(Pipeline::depth_state())
@@ -302,11 +300,11 @@ where
         };
 
         let inner = self.inner.build();
-        let matrix = ortho(width, height);
+        let matrix = ortho(config.width as f32, config.height as f32);
 
         let pipeline = Pipeline::new(
             device,
-            render_format,
+            config.format.clone(),
             depth,
             inner.texture_dimensions(),
             matrix,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,8 @@ pub struct ScissorRegion {
     pub out_height: u32,
 }
 
+pub type Matrix = [[f32; 4]; 4];
+
 impl ScissorRegion {
     /// Checks if the region is contained in surface bounds at all.
     pub(crate) fn is_contained(&self) -> bool {
@@ -241,7 +243,7 @@ where
     /// (`cross product`-ing).
     pub fn update_matrix<M>(&mut self, matrix: M, queue: &wgpu::Queue)
     where
-        M: Into<[[f32; 4]; 4]>,
+        M: Into<Matrix>,
     {
         self.pipeline.update_matrix(matrix.into(), queue);
     }
@@ -266,7 +268,7 @@ where
 /// Builder for [`TextBrush`].
 pub struct BrushBuilder<Depth, F, H = DefaultSectionHasher> {
     inner: glyph_brush::GlyphBrushBuilder<F, H>,
-    matrix: Option<[[f32; 4]; 4]>,
+    matrix: Option<Matrix>,
     phantom: std::marker::PhantomData<Depth>,
 }
 
@@ -317,7 +319,7 @@ where
     /// To update the render matrix use [`TextBrush::update_matrix()`].
     pub fn with_matrix<M>(mut self, matrix: M) -> Self
     where
-        M: Into<[[f32; 4]; 4]>,
+        M: Into<Matrix>,
     {
         self.matrix = Some(matrix.into());
         self
@@ -406,10 +408,7 @@ where
     }
 }
 
-fn create_matrix(
-    matrix: Option<[[f32; 4]; 4]>,
-    config: &wgpu::SurfaceConfiguration,
-) -> [[f32; 4]; 4] {
+fn create_matrix(matrix: Option<Matrix>, config: &wgpu::SurfaceConfiguration) -> Matrix {
     if let Some(matrix) = matrix {
         matrix
     } else {
@@ -419,7 +418,7 @@ fn create_matrix(
 
 /// Creates an orthographic matrix with given dimensions `width` and `height`.
 #[rustfmt::skip]
-pub fn ortho(width: f32, height: f32) -> [[f32; 4]; 4] {
+pub fn ortho(width: f32, height: f32) -> Matrix {
     [
         [2.0 / width, 0.0,          0.0, 0.0],
         [0.0,        -2.0 / height, 0.0, 0.0],

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -4,7 +4,7 @@ use glyph_brush::{
 };
 use wgpu::{util::DeviceExt, CommandBuffer};
 
-use crate::cache::Cache;
+use crate::{cache::Cache, Matrix};
 
 /// Responsible for drawing text.
 pub struct Pipeline<Depth> {
@@ -26,7 +26,7 @@ impl<Depth> Pipeline<Depth> {
         render_format: wgpu::TextureFormat,
         depth_stencil: Option<wgpu::DepthStencilState>,
         tex_dimensions: (u32, u32),
-        matrix: [[f32; 4]; 4],
+        matrix: Matrix,
     ) -> Pipeline<Depth> {
         let cache = Cache::new(device, tex_dimensions, matrix);
 
@@ -169,7 +169,7 @@ impl<Depth> Pipeline<Depth> {
     }
 
     #[inline]
-    pub fn update_matrix(&mut self, matrix: [[f32; 4]; 4], queue: &wgpu::Queue) {
+    pub fn update_matrix(&mut self, matrix: Matrix, queue: &wgpu::Queue) {
         self.cache.update_matrix(matrix, queue);
     }
 


### PR DESCRIPTION
Make important dependencies accessible for the end user. Like FontRef
for example, so a brush can be stored in a struct.

In my project I have a state struct so I can split a lot of the render code, but I can't use your library because dependencies are private. Anyway keep up the good work.