### PR TITLE
wgpu 26.0.0 update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wgpu_text"
 authors = ["Leon (Blatko1)"]
-version = "0.9.3"
+version = "26.0.0"
 edition = "2024"
 description = "A simple 2D text renderer for wgpu."
 license = "MIT"
@@ -12,13 +12,13 @@ categories = ["graphics", "rendering"]
 include = ["src/**/*", "LICENSE", "Cargo.toml", "README.md", ".gitignore"]
 
 [dependencies]
-wgpu = "25.0.0"
+wgpu = "26.0.1"
 glyph_brush = "0.7.12"
 log = "0.4.27"
 bytemuck = { version = "1.22.0", features = ["derive"] }
 
 [dev-dependencies]
-wgpu = { version = "25.0.0", features = ["spirv"] }
+wgpu = { version = "26.0.1", features = ["spirv"] }
 winit = "0.30.9"
 pollster = "0.4.0"
 env_logger = "0.11.8"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-wgpu_text = "0.9.3"
+wgpu_text = "26.0.0"
 ```
 
 ## **Usage**

--- a/examples/ctx.rs
+++ b/examples/ctx.rs
@@ -21,6 +21,7 @@ impl Ctx {
         let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
             backends,
             flags: wgpu::InstanceFlags::default(),
+            memory_budget_thresholds: Default::default(),
             backend_options: wgpu::BackendOptions {
                 gl: wgpu::GlBackendOptions {
                     gles_minor_version: wgpu::Gles3MinorVersion::Automatic,

--- a/examples/custom_target/custom_target.rs
+++ b/examples/custom_target/custom_target.rs
@@ -357,6 +357,7 @@ impl ApplicationHandler for State<'_> {
                             label: Some("Custom Surface Render Pass"),
                             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                                 view: self.texture_view.as_ref().unwrap(),
+                                depth_slice: None,
                                 resolve_target: None,
                                 ops: wgpu::Operations {
                                     load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
@@ -378,6 +379,7 @@ impl ApplicationHandler for State<'_> {
                             label: Some("Custom Surface Render Pass"),
                             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                                 view: &view,
+                                depth_slice: None,
                                 resolve_target: None,
                                 ops: wgpu::Operations {
                                     load: wgpu::LoadOp::Clear(wgpu::Color {

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -244,6 +244,7 @@ impl ApplicationHandler for State<'_> {
                             label: Some("Render Pass"),
                             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                                 view: &view,
+                                depth_slice: None,
                                 resolve_target: None,
                                 ops: wgpu::Operations {
                                     load: wgpu::LoadOp::Clear(wgpu::Color {

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -186,6 +186,7 @@ impl ApplicationHandler for State<'_> {
                             label: Some("Render Pass"),
                             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                                 view: &view,
+                                depth_slice: None,
                                 resolve_target: None,
                                 ops: wgpu::Operations {
                                     load: wgpu::LoadOp::Clear(wgpu::Color {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -226,6 +226,7 @@ impl ApplicationHandler for State<'_> {
                             label: Some("Render Pass"),
                             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                                 view: &view,
+                                depth_slice: None,
                                 resolve_target: None,
                                 ops: wgpu::Operations {
                                     load: wgpu::LoadOp::Clear(wgpu::Color {


### PR DESCRIPTION
Also with this PR I want to propose to change how `wgpu-text` is versioned. Since it heavily depends on `wgpu` I think it would be more convenient to use the same versioning pattern like `wgpu` does and reflect which `wgpu` version this version of `wgpu-text` is compatible with. I remember it the past I had some difficulties with matching versions of `wgpu-text` and `wgpu`.