### PR TITLE
Remove no longer needed lifetime constraints

### DIFF
--- a/src/brush.rs
+++ b/src/brush.rs
@@ -133,7 +133,7 @@ where
 
     /// Draws all sections queued with [`queue`](#method.queue) function.
     #[inline]
-    pub fn draw<'pass>(&'pass self, rpass: &mut wgpu::RenderPass<'pass>) {
+    pub fn draw(&self, rpass: &mut wgpu::RenderPass) {
         self.pipeline.draw(rpass)
     }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -89,7 +89,7 @@ impl Pipeline {
     }
 
     /// Raw draw.
-    pub fn draw<'pass>(&'pass self, rpass: &mut wgpu::RenderPass<'pass>) {
+    pub fn draw(&self, rpass: &mut wgpu::RenderPass) {
         if self.vertices != 0 {
             rpass.set_pipeline(&self.inner);
             rpass.set_vertex_buffer(0, self.vertex_buffer.slice(..));


### PR DESCRIPTION
Since wgpu 22.0.0 these lifetime constraints are no longer needed.
With this change, users of wgpu-text no longer need to ensure that
the TextBrush outlives the render pass.