### PR TITLE
Fixes a winit crash in examples

### DIFF
--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -282,15 +282,16 @@ impl ApplicationHandler for State<'_> {
 
     fn new_events(&mut self, _elwt: &ActiveEventLoop, _cause: winit::event::StartCause) {
         if self.target_framerate <= self.delta_time.elapsed() {
-            self.window.clone().unwrap().request_redraw();
-            self.delta_time = Instant::now();
-            self.fps += 1;
-            if self.fps_update_time.elapsed().as_millis() > 1000 {
-                let window = self.window.as_mut().unwrap();
-                window
-                    .set_title(&format!("wgpu-text: 'depth' example, FPS: {}", self.fps));
-                self.fps = 0;
-                self.fps_update_time = Instant::now();
+            if let Some(window) = self.window.clone().as_mut() {
+                window.request_redraw();
+                self.delta_time = Instant::now();
+                self.fps += 1;
+                if self.fps_update_time.elapsed().as_millis() > 1000 {
+                    window
+                        .set_title(&format!("wgpu-text: 'depth' example, FPS: {}", self.fps));
+                    self.fps = 0;
+                    self.fps_update_time = Instant::now();
+                }
             }
         }
     }

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -215,17 +215,18 @@ impl ApplicationHandler for State<'_> {
 
     fn new_events(&mut self, _elwt: &ActiveEventLoop, _cause: winit::event::StartCause) {
         if self.target_framerate <= self.delta_time.elapsed() {
-            self.window.clone().unwrap().request_redraw();
-            self.delta_time = Instant::now();
-            self.fps += 1;
-            if self.fps_update_time.elapsed().as_millis() > 1000 {
-                let window = self.window.as_mut().unwrap();
-                window.set_title(&format!(
-                    "wgpu-text: 'performance' example, FPS: {}",
-                    self.fps
-                ));
-                self.fps = 0;
-                self.fps_update_time = Instant::now();
+            if let Some(window) = self.window.clone().as_mut() {
+                window.request_redraw();
+                self.delta_time = Instant::now();
+                self.fps += 1;
+                if self.fps_update_time.elapsed().as_millis() > 1000 {
+                    window.set_title(&format!(
+                        "wgpu-text: 'performance' example, FPS: {}",
+                        self.fps
+                    ));
+                    self.fps = 0;
+                    self.fps_update_time = Instant::now();
+                }
             }
         }
     }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -255,17 +255,18 @@ impl ApplicationHandler for State<'_> {
 
     fn new_events(&mut self, _elwt: &ActiveEventLoop, _cause: winit::event::StartCause) {
         if self.target_framerate <= self.delta_time.elapsed() {
-            self.window.clone().unwrap().request_redraw();
-            self.delta_time = Instant::now();
-            self.fps += 1;
-            if self.fps_update_time.elapsed().as_millis() > 1000 {
-                let window = self.window.as_mut().unwrap();
-                window.set_title(&format!(
-                    "wgpu-text: 'simple' example, FPS: {}",
-                    self.fps
-                ));
-                self.fps = 0;
-                self.fps_update_time = Instant::now();
+            if let Some(window) = self.window.clone().as_mut() {
+                window.request_redraw();
+                self.delta_time = Instant::now();
+                self.fps += 1;
+                if self.fps_update_time.elapsed().as_millis() > 1000 {
+                    window.set_title(&format!(
+                        "wgpu-text: 'simple' example, FPS: {}",
+                        self.fps
+                    ));
+                    self.fps = 0;
+                    self.fps_update_time = Instant::now();
+                }
             }
         }
     }


### PR DESCRIPTION
This PR fixes a crash in all examples.
`self.window` is always `None` in the `fn new_events()` at the beginning.

```
kirill@kirill-Laptop wgpu-text % cargo run --example simple 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
     Running `target/debug/examples/simple`

thread 'main' panicked at examples/simple.rs:258:33:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'main' panicked at library/core/src/panicking.rs:225:5:
panic in a function that cannot unwind
stack backtrace:
   0:        0x102e612a8 - std::backtrace_rs::backtrace::libunwind::trace::h287be7a7e88cef96
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/std/src/../../backtrace/src/backtrace/libunwind.rs:117:9
   1:        0x102e612a8 - std::backtrace_rs::backtrace::trace_unsynchronized::h19530ebe37664308
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/std/src/../../backtrace/src/backtrace/mod.rs:66:14
   2:        0x102e612a8 - std::sys::backtrace::_print_fmt::h29eacbcf245c039f
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/std/src/sys/backtrace.rs:66:9
   3:        0x102e612a8 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h70e6b096d59bfac8
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/std/src/sys/backtrace.rs:39:26
   4:        0x102e7ba28 - core::fmt::rt::Argument::fmt::hc6c54bf60a1d62ea
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/core/src/fmt/rt.rs:173:76
   5:        0x102e7ba28 - core::fmt::write::h53af9ece43a40ba1
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/core/src/fmt/mod.rs:1468:25
   6:        0x102e5f188 - std::io::default_write_fmt::h9a135391e5092330
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/std/src/io/mod.rs:639:11
   7:        0x102e5f188 - std::io::Write::write_fmt::h2766a1cd222fcf5a
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/std/src/io/mod.rs:1954:13
   8:        0x102e6115c - std::sys::backtrace::BacktraceLock::print::h5e7eca4b3e2071bf
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/std/src/sys/backtrace.rs:42:9
   9:        0x102e621c4 - std::panicking::default_hook::{{closure}}::h98e138d484a6730a
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/std/src/panicking.rs:300:27
  10:        0x102e6201c - std::panicking::default_hook::hc3feac177b5af356
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/std/src/panicking.rs:327:9
  11:        0x102e62c64 - std::panicking::rust_panic_with_hook::hac816ea162e6ab86
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/std/src/panicking.rs:833:13
  12:        0x102e62858 - std::panicking::begin_panic_handler::{{closure}}::h585ae7aaa66876f5
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/std/src/panicking.rs:699:13
  13:        0x102e61758 - std::sys::backtrace::__rust_end_short_backtrace::h4a349d135c5a66a9
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/std/src/sys/backtrace.rs:174:18
  14:        0x102e6255c - __rustc[b6a6beb7f6add470]::rust_begin_unwind
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/std/src/panicking.rs:697:5
  15:        0x102eeccdc - core::panicking::panic_nounwind_fmt::runtime::h777c74b8a37d29f7
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/core/src/panicking.rs:117:22
  16:        0x102eeccdc - core::panicking::panic_nounwind_fmt::h230117ca16fdf4dc
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/core/src/intrinsics/mod.rs:2367:9
  17:        0x102eecd54 - core::panicking::panic_nounwind::h8b8d9ae5d027e431
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/core/src/panicking.rs:225:5
  18:        0x102eecec0 - core::panicking::panic_cannot_unwind::hfd10d68c5dfe8ead
                               at /rustc/f8e355c230c6eb7b78ffce6a92fd81f78c890524/library/core/src/panicking.rs:346:5
  19:        0x10252563c - winit::platform_impl::macos::app_state::ApplicationDelegate::app_did_finish_launching::hd7c723781d0b268e
                               at /Users/kirill/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/objc2-0.5.2/src/macros/declare_class.rs:981:25
  20:        0x1908d73bc - <unknown>
  21:        0x190966a78 - <unknown>
  22:        0x1909669bc - <unknown>
  23:        0x1908a6808 - <unknown>
  24:        0x191e60680 - <unknown>
  25:        0x1948091bc - <unknown>
  26:        0x194808f6c - <unknown>
  27:        0x194807568 - <unknown>
  28:        0x19480717c - <unknown>
  29:        0x191e88e40 - <unknown>
  30:        0x191e88c38 - <unknown>
thread caused non-unwinding panic. aborting.
zsh: abort      cargo run --example simple
```